### PR TITLE
Add user data config to support new EKS AMI

### DIFF
--- a/templates/worker-nodes-init.tpl
+++ b/templates/worker-nodes-init.tpl
@@ -1,20 +1,6 @@
-#!/bin/bash -xe
-
-CA_CERTIFICATE_DIRECTORY=/etc/kubernetes/pki
-CA_CERTIFICATE_FILE_PATH=$CA_CERTIFICATE_DIRECTORY/ca.crt
-mkdir -p $CA_CERTIFICATE_DIRECTORY
-echo "${authority_data}" | base64 -d >  $CA_CERTIFICATE_FILE_PATH
-INTERNAL_IP=$(curl -s http://169.254.169.254/latest/meta-data/local-ipv4)
-sed -i s,MASTER_ENDPOINT,"${eks_endpoint}",g /var/lib/kubelet/kubeconfig
-sed -i s,CLUSTER_NAME,"${eks_name}",g /var/lib/kubelet/kubeconfig
-sed -i s,REGION,us-east-1,g /etc/systemd/system/kubelet.service
-sed -i s,MAX_PODS,20,g /etc/systemd/system/kubelet.service
-sed -i s,MASTER_ENDPOINT,"${eks_endpoint}",g /etc/systemd/system/kubelet.service
-sed -i s,INTERNAL_IP,"$INTERNAL_IP",g /etc/systemd/system/kubelet.service
-DNS_CLUSTER_IP=10.100.0.10
-if [[ $INTERNAL_IP == 10.* ]] ; then DNS_CLUSTER_IP=172.20.0.10; fi
-sed -i s,DNS_CLUSTER_IP,$DNS_CLUSTER_IP,g /etc/systemd/system/kubelet.service
-sed -i s,CERTIFICATE_AUTHORITY_FILE,$CA_CERTIFICATE_FILE_PATH,g /var/lib/kubelet/kubeconfig
-sed -i s,CLIENT_CA_FILE,$CA_CERTIFICATE_FILE_PATH,g  /etc/systemd/system/kubelet.service
-systemctl daemon-reload
-systemctl restart kubelet
+#!/bin/bash
+set -o xtrace
+/etc/eks/bootstrap.sh \
+  --apiserver-endpoint '${eks_endpoint}' \
+  --b64-cluster-ca '${authority_data}' \
+  '${eks_name}'

--- a/test/test_fixture/main.tf
+++ b/test/test_fixture/main.tf
@@ -8,7 +8,7 @@ module "eks" {
   vpc_cidr_block       = "10.0.0.0/16"
   vpc_instance_tenancy = "default"
 
-  workers_ami_id        = "ami-dea4d5a1"
+  workers_ami_id        = "ami-0440e4f6b9713faf6"
   workers_instance_type = "t2.small"
   alarm_out_threshold   = 50
   alarm_in_threshold    = 30

--- a/variables.tf
+++ b/variables.tf
@@ -189,8 +189,9 @@ variable "workers_role_detach_policies" {
 
 variable "workers_policies" {
   default = [
-    "arn:aws:iam::aws:policy/AmazonEKSClusterPolicy",
-    "arn:aws:iam::aws:policy/AmazonEKSServicePolicy",
+    "arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy",
+    "arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy",
+    "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly",
   ]
 }
 

--- a/worker-nodes.tf
+++ b/worker-nodes.tf
@@ -141,12 +141,14 @@ resource "aws_launch_configuration" "workers_launch_configuration" {
   key_name        = "${var.workers_key_name}"
   security_groups = ["${aws_security_group.workers_sg.id}"]
 
-  user_data = "${
-    var.workers_custom_user_data != ""
-      ? var.workers_custom_user_data
-      : var.workers_extend_user_data != ""
-      ? format("%s\n%s", data.template_file.init.rendered, var.workers_extend_user_data)
-      : data.template_file.init.rendered
+  user_data_base64 = "${
+    base64encode(
+      var.workers_custom_user_data != ""
+        ? var.workers_custom_user_data
+        : var.workers_extend_user_data != ""
+          ? format("%s\n%s", data.template_file.init.rendered, var.workers_extend_user_data)
+          : data.template_file.init.rendered
+    )
   }"
 
   iam_instance_profile = "${aws_iam_instance_profile.workers_instance_profile.id}"


### PR DESCRIPTION
# Context

AWS Sent this email yesterday:

_Hello, The EKS Team has recently released v24 of the EKS Optimized AMI. The latest AMI contains bugfixes, security patches, and performance optimizations. Please ensure that you are also using the latest CloudFormation template, released on August 30th, 2018. You can check the "description" parameter inside the template to identify its release date. To find the latest AMI and CloudFormation template, please see the EKS documentation here: https://docs.aws.amazon.com/eks/latest/userguide/eks-optimized-ami.html_

According to their documentation, you don't have to provide the _complex_ user data needed before to set up the worker nodes as a script is now baked inside the AMI in `/etc/eks/bootstrap.sh`.

## Changes

* `worker-nodes-init.tpl` init template 
* encode the user data in `base64`
* use new, official AMI in test kitchen
* **fix** worker nodes policies as the EKS cluster ones were attached before to it